### PR TITLE
Lowercase the name compared to a service's name

### DIFF
--- a/pydd/core.py
+++ b/pydd/core.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+#. -*- coding: utf-8 -*-
 """
 @author: Ardalan MEHRANI <ardalan77400@gmail.com>
 @brief:
@@ -123,7 +123,7 @@ class AbstractModels(AbstractDDCalls):
 
         if self.sname:
             for service in self.get_info()['head']['services']:
-                if service['name'] == self.sname:
+                if service['name'] == self.sname.lower(): # DD lowercases services' name
                     self.delete_service(self.sname, clear="mem")
         else:
             self.sname = "pyDD_{}".format(time_utils.fulltimestamp())


### PR DESCRIPTION
Comparison of a service's name that is running on DeepDetect and a service name not yet on DeepDetect should be modified.

Indeed DeepDetect lowercases the service name so we will never enter the bloc.
https://github.com/beniz/deepdetect/commit/99a96173b81a742dd489620aa44b46f13fb9e999

Then, lowercasing the compared name should be sufficient.